### PR TITLE
fix: make `<Link>` inert for `setupRenderingTest`

### DIFF
--- a/tests/helpers/wait-for-error.ts
+++ b/tests/helpers/wait-for-error.ts
@@ -1,0 +1,47 @@
+import { waitUntil } from '@ember/test-helpers';
+
+import Ember from 'ember';
+
+import { on, off } from 'rsvp';
+
+/**
+ * I would be using `ember-qunit-assert-helpers` here, but it does not work with
+ * async rendering. :(
+ *
+ * Adapted from https://github.com/workmanw/ember-qunit-assert-helpers/issues/18#issuecomment-390003905
+ */
+export default async function waitForError(
+  callback: () => Promise<unknown>,
+  options?: Parameters<typeof waitUntil>[1]
+) {
+  const originalEmberListener = Ember.onerror;
+  const originalWindowListener = window.onerror;
+
+  let error: Error | undefined;
+  Ember.onerror = uncaughtError => {
+    error = uncaughtError;
+  };
+  window.onerror = (
+    _message,
+    _source,
+    _lineNumber,
+    _columnNumber,
+    uncaughtError
+  ) => {
+    error = uncaughtError;
+  };
+  on('error', Ember.onerror);
+
+  await Promise.all([
+    waitUntil(() => error, options).finally(() => {
+      Ember.onerror = originalEmberListener;
+      window.onerror = originalWindowListener;
+      off('error', Ember.onerror);
+    }),
+    callback()
+  ]);
+
+  if (!error) throw new Error('No Error was thrown.');
+
+  return error;
+}

--- a/tests/integration/components/link-test.ts
+++ b/tests/integration/components/link-test.ts
@@ -1,0 +1,52 @@
+import { render, click } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+
+import waitForError from 'dummy/tests/helpers/wait-for-error';
+
+module('Integration | Component | link', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Regression for: https://github.com/buschtoens/ember-link/issues/126
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <Link @route="foo" as |l|>
+        <a
+          data-test-link
+          href={{l.href}}
+          class={{if l.isActive "is-active"}}
+          {{on "click" l.transitionTo}}
+        >
+          Link
+        </a>
+      </Link>
+    `);
+
+    assert.dom('[data-test-link]').hasAttribute('href', '');
+    assert.dom('[data-test-link]').hasNoClass('is-active');
+  });
+
+  test('triggering a transition has no effect', async function(assert) {
+    await render(hbs`
+      <Link @route="foo" as |l|>
+        <a
+          data-test-link
+          href={{l.href}}
+          class={{if l.isActive "is-active"}}
+          {{on "click" l.transitionTo}}
+        >
+          Link
+        </a>
+      </Link>
+    `);
+
+    const error = await waitForError(() => click('[data-test-link]'));
+    assert.ok(error instanceof Error);
+    assert.strictEqual(
+      error.message,
+      'Assertion Failed: You can only call `transitionTo`, when the router is initialized, e.g. when using `setupApplicationTest`.'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #126.