### PR TITLE
Fix models normalization in link helper

### DIFF
--- a/addon/helpers/link.ts
+++ b/addon/helpers/link.ts
@@ -117,10 +117,12 @@ export default class LinkHelper extends Helper {
         ? named.models
         : named.model
         ? [named.model]
-        : (positional.slice(
+        : positional.length > 1
+        ? (positional.slice(
             1,
             positionalQueryParameters ? -1 : undefined
-          ) as RouteModel[]),
+          ) as RouteModel[])
+        : undefined,
       query: named.query ?? positionalQueryParameters
     };
   }


### PR DESCRIPTION
The code was normalizing a missing `models` argument to `models: []` meaning the `cacheKey` for `TestLink`s created via `linkFor` was different from the `cacheKey` for `TestLink`s created via the `test` helper.