### PR TITLE
fix(Link): Use `currentTransitionStack` to enable auto-tracking

### DIFF
--- a/addon/link.ts
+++ b/addon/link.ts
@@ -87,7 +87,7 @@ export default class Link {
    */
   get isActive(): boolean {
     if (!this._linkManager.isRouterInitialized) return false;
-    this._linkManager.router.currentURL; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    this._linkManager.currentTransitionStack; // eslint-disable-line @typescript-eslint/no-unused-expressions
     return this._linkManager.router.isActive(...this._routeArgs);
   }
 
@@ -97,7 +97,7 @@ export default class Link {
    */
   get isActiveWithoutQueryParams(): boolean {
     if (!this._linkManager.isRouterInitialized) return false;
-    this._linkManager.router.currentURL; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    this._linkManager.currentTransitionStack; // eslint-disable-line @typescript-eslint/no-unused-expressions
     return this._linkManager.router.isActive(
       this.routeName,
       // Unfortunately TypeScript is not clever enough to support "rest"
@@ -114,7 +114,7 @@ export default class Link {
    */
   get isActiveWithoutModels(): boolean {
     if (!this._linkManager.isRouterInitialized) return false;
-    this._linkManager.router.currentURL; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    this._linkManager.currentTransitionStack; // eslint-disable-line @typescript-eslint/no-unused-expressions
     return this._linkManager.router.isActive(this.routeName);
   }
 


### PR DESCRIPTION
`currentURL` appears to update when the transition starts, but not anymore when it has ended. This leads to `isActive` not updating correctly if the `model()` hook is taking too long to load data. The `currentTransitionStack` however is changing in the `routeDidChange` event handler, which ensures that `isActive` (and friends) are updating at the right time.

If I understand the issue correctly, this should resolve #42.