### PR TITLE
fix: add support for Ember 3.23.0

### DIFF
--- a/addon/helpers/link.ts
+++ b/addon/helpers/link.ts
@@ -77,11 +77,10 @@ export default class LinkHelper extends Helper {
       Boolean(positional[0] || named.route)
     );
 
-    const positionalQueryParameters = isQueryParams(
-      positional[positional.length - 1]
-    )
-      ? (positional[positional.length - 1] as QueryParams)
-      : undefined;
+    const positionalQueryParameters =
+      positional.length > 0 && isQueryParams(positional[positional.length - 1])
+        ? (positional[positional.length - 1] as QueryParams)
+        : undefined;
 
     assert(
       `Query parameters either need to be specified as the last positional parameter or as the named 'query' parameter.`,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-on-modifier": "^1.0.1",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
-    "ember-source": "~3.21.1",
+    "ember-source": "~3.23.0-beta.5",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.13.0",
     "ember-try": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6886,10 +6886,10 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.21.1:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.21.1.tgz#e1bfb20a3db91c21415256e5949a32085a2c23ab"
-  integrity sha512-zG3FCd++91/OQgYeMeGJequ1u0uLFK3xeilHYL4CNrwgQAit0vju/s8x7H4fVnVxOxYhsFUXAsTMSsvgqbaqpQ==
+ember-source@~3.23.0-beta.5:
+  version "3.23.0-beta.5"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.23.0-beta.5.tgz#bd729fdc924d7721bcee311d0060c14f03622366"
+  integrity sha512-UJ96yV23gOOjt/9JWd+7/SuoA6m80IaWhgbs9aOrXJeswOfS5gcj/LanENBa1yD5zxSKm7SGAxFVIlyk1gd35g==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"


### PR DESCRIPTION
Caused by https://github.com/emberjs/ember.js/pull/19273.

Original implementation is technically correct and ES standard compliant, but not really clean. The explicit check solves both issues.

---

Latest canary is still broken, because of https://github.com/emberjs/ember.js/pull/19080.

The `Router` is now implicitly initialized whenever `_router` is accessed.