### PR TITLE
fix: prevent `super.transitionTo()` call when Cmd+Click is used

### DIFF
--- a/addon/link.ts
+++ b/addon/link.ts
@@ -228,7 +228,7 @@ export default class Link {
    * Transition into the target route.
    */
   @action
-  transitionTo(): Transition {
+  transitionTo(): Transition | undefined {
     assert(
       'You can only call `transitionTo`, when the router is initialized, e.g. when using `setupApplicationTest`.',
       this._linkManager.isRouterInitialized
@@ -242,7 +242,7 @@ export default class Link {
    * possible.
    */
   @action
-  replaceWith(): Transition {
+  replaceWith(): Transition | undefined {
     assert(
       'You can only call `replaceWith`, when the router is initialized, e.g. when using `setupApplicationTest`.',
       this._linkManager.isRouterInitialized
@@ -284,7 +284,7 @@ export class UILink extends Link {
    * Optionally call `preventDefault()`, if an `Event` is passed in.
    */
   @action
-  transitionTo(event?: Event | unknown): Transition {
+  transitionTo(event?: Event | unknown): Transition | undefined {
     if (isMouseEvent(event) && !isUnmodifiedLeftClick(event)) return;
 
     // Intentionally putting this *before* the assertion to prevent navigating
@@ -301,7 +301,7 @@ export class UILink extends Link {
    * Optionally call `preventDefault()`, if an `Event` is passed in.
    */
   @action
-  replaceWith(event?: Event | unknown): Transition {
+  replaceWith(event?: Event | unknown): Transition | undefined {
     if (isMouseEvent(event) && !isUnmodifiedLeftClick(event)) return;
 
     // Intentionally putting this *before* the assertion to prevent navigating

--- a/addon/link.ts
+++ b/addon/link.ts
@@ -272,8 +272,7 @@ export class UILink extends Link {
   private preventDefault(event?: Event | unknown) {
     if (
       (this._params.preventDefault ?? true) &&
-      typeof (event as Event)?.preventDefault === 'function' &&
-      (!isMouseEvent(event) || isUnmodifiedLeftClick(event))
+      typeof (event as Event)?.preventDefault === 'function'
     ) {
       (event as Event).preventDefault();
     }
@@ -286,6 +285,8 @@ export class UILink extends Link {
    */
   @action
   transitionTo(event?: Event | unknown): Transition {
+    if (isMouseEvent(event) && !isUnmodifiedLeftClick(event)) return;
+
     // Intentionally putting this *before* the assertion to prevent navigating
     // away in case of a failed assertion.
     this.preventDefault(event);
@@ -301,6 +302,8 @@ export class UILink extends Link {
    */
   @action
   replaceWith(event?: Event | unknown): Transition {
+    if (isMouseEvent(event) && !isUnmodifiedLeftClick(event)) return;
+
     // Intentionally putting this *before* the assertion to prevent navigating
     // away in case of a failed assertion.
     this.preventDefault(event);


### PR DESCRIPTION
Unfortunately, I screwed up when I implemented #473 😞 

Before all of this, when you Cmd+Click a link it would open the link in the same tab by doing `transitionTo()` and calling `preventDefault()`.

After #473, it would open the link in a new tab, due to the skipped `preventDefault()`, but it would also navigate to the link in the current tab due to the `transitionTo()` call that is still happening.

This PR changes the code to skip both `preventDefault()` **and** `transitionTo()` if we detect that the user used a modifier key or a non-primary mouse button. This results in the link only being opened in the new tab, but the current tab staying on the same page.