### PR TITLE
tests/acceptance: Avoid multiple `Router.map()` calls

### DIFF
--- a/tests/dummy/app/router.ts
+++ b/tests/dummy/app/router.ts
@@ -7,4 +7,13 @@ export default class DummyRouter extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-DummyRouter.map(function () {});
+DummyRouter.map(function () {
+  this.route('foo');
+  this.route('bar');
+
+  this.route('with-model', { path: 'with-model/:id' });
+
+  this.route('parent', { path: 'parent/:parent_id' }, function () {
+    this.route('child', { path: 'child/:child_id' });
+  });
+});


### PR DESCRIPTION
Apparently these route defs persist between calls, even between separate tests. We can instead defined them in the dummy application route and use this fixed set of routes.