### PR TITLE
Adjust CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       matrix:
         scenario:
           - ember-3.15
+          - ember-3.16
+          - ember-3.20
 #          - ember-release
 #          - ember-beta
 #          - ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
       matrix:
         scenario:
           - ember-3.15
-          - ember-release
-          - ember-beta
-          - ember-canary
+#          - ember-release
+#          - ember-beta
+#          - ember-canary
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -20,6 +20,22 @@ module.exports = function () {
           }
         },
         {
+          name: 'ember-3.16',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.16.0'
+            }
+          }
+        },
+        {
+          name: 'ember-3.20',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.20.0'
+            }
+          }
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
This PR temporarily disables the broken ember-try scenarios until we have fixed compatibility with Ember 3.24 and above, and it adds two new scenarios for the 3.16/20 LTS releases.