### PR TITLE
tests/components/link: Add "incomplete model" test

### DIFF
--- a/tests/dummy/app/router.ts
+++ b/tests/dummy/app/router.ts
@@ -15,5 +15,6 @@ DummyRouter.map(function () {
 
   this.route('parent', { path: 'parent/:parent_id' }, function () {
     this.route('child', { path: 'child/:child_id' });
+    this.route('second-child');
   });
 });

--- a/tests/integration/components/link-test.ts
+++ b/tests/integration/components/link-test.ts
@@ -49,4 +49,46 @@ module('Integration | Component | link', function (hooks) {
       'Assertion Failed: You can only call `transitionTo`, when the router is initialized, e.g. when using `setupApplicationTest`.'
     );
   });
+
+  module('with incomplete models', function () {
+    test('it renders', async function (assert) {
+      await render(hbs`
+        <Link @route="parent.second-child" as |l|>
+          <a
+            data-test-link
+            href={{l.href}}
+            class={{if l.isActive "is-active"}}
+            {{on "click" l.transitionTo}}
+          >
+            Link
+          </a>
+        </Link>
+      `);
+
+      assert.dom('[data-test-link]').hasAttribute('href', '');
+      assert.dom('[data-test-link]').hasNoClass('is-active');
+    });
+
+    test('triggering a transition has no effect', async function (assert) {
+      await render(hbs`
+        <Link @route="parent.second-child" as |l|>
+          <a
+            data-test-link
+            href={{l.href}}
+            class={{if l.isActive "is-active"}}
+            {{on "click" l.transitionTo}}
+          >
+            Link
+          </a>
+        </Link>
+      `);
+
+      const error = await waitForError(() => click('[data-test-link]'));
+      assert.ok(error instanceof Error);
+      assert.strictEqual(
+        error.message,
+        'Assertion Failed: You can only call `transitionTo`, when the router is initialized, e.g. when using `setupApplicationTest`.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
When a component is only used in subroutes of a route with a dynamic segment then a link in that component does not need to specifically set that dynamic segment. With Ember 3.23 and below such links in rendering tests will be treated just like other links: with an empty `href`.