### PR TITLE
services/link-manager: Fix typo in `getLinkParamsFromURL()` method name

### DIFF
--- a/addon/helpers/link.ts
+++ b/addon/helpers/link.ts
@@ -65,7 +65,7 @@ export default class LinkHelper extends Helper {
         ] as (keyof LinkHelperNamedParams)[]).some(name => named[name])
       );
 
-      return this.linkManager.getLinkPramsFromURL(named.fromURL);
+      return this.linkManager.getLinkParamsFromURL(named.fromURL);
     }
 
     assert(

--- a/addon/services/link-manager.ts
+++ b/addon/services/link-manager.ts
@@ -61,7 +61,7 @@ export default class LinkManagerService extends Service {
    *
    * If the URL cannot be recognized by the router, an error is thrown.
    */
-  getLinkPramsFromURL(url: string): LinkParams {
+  getLinkParamsFromURL(url: string): LinkParams {
     const routeInfo = this.router.recognize(url);
     return LinkManagerService.getLinkParamsFromRouteInfo(routeInfo);
   }


### PR DESCRIPTION
a "pram" is something slightly different...... 😂 