### PR TITLE
Fix Ember 3.24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           - ember-3.15
           - ember-3.16
           - ember-3.20
+          - ember-3.24
           - ember-release
           - ember-beta
 #          - ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
           - ember-3.15
           - ember-3.16
           - ember-3.20
-#          - ember-release
-#          - ember-beta
+          - ember-release
+          - ember-beta
 #          - ember-canary
     steps:
       - name: Checkout Code

--- a/addon-test-support/setup-link.ts
+++ b/addon-test-support/setup-link.ts
@@ -6,13 +6,6 @@ import TestInstrumentedLinkManagerService from './-private/services/test-instrum
 
 export default function setupLink(hooks: NestedHooks) {
   hooks.beforeEach(function (this: TestContext) {
-    const router = this.owner.lookup('service:router');
-
-    assert(
-      'ember-link.setupLink: Test helpers can only be used in integration tests',
-      !router._router._routerMicrolib
-    );
-
     assert(
       'ember-link.setupLink: You have already called `setupLink` once',
       !this.owner.hasRegistration('service:link-manager') ||

--- a/addon/services/link-manager.ts
+++ b/addon/services/link-manager.ts
@@ -30,8 +30,7 @@ export default class LinkManagerService extends Service {
    * @see https://github.com/buschtoens/ember-link/issues/126
    */
   get isRouterInitialized() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return Boolean((this.router as any)._router._routerMicrolib);
+    return this.router.currentURL !== null;
   }
 
   /**

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -36,6 +36,14 @@ module.exports = function () {
           }
         },
         {
+          name: 'ember-3.24',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.24.0'
+            }
+          }
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-on-modifier": "^1.0.1",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
-    "ember-source": "~3.23.0-beta.5",
+    "ember-source": "~3.24.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.17.0",
     "ember-try": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6229,10 +6229,10 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.23.0-beta.5:
-  version "3.23.0-beta.5"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.23.0-beta.5.tgz#bd729fdc924d7721bcee311d0060c14f03622366"
-  integrity sha512-UJ96yV23gOOjt/9JWd+7/SuoA6m80IaWhgbs9aOrXJeswOfS5gcj/LanENBa1yD5zxSKm7SGAxFVIlyk1gd35g==
+ember-source@~3.24.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.24.1.tgz#183cf2f556921726406c05f86224091133c33790"
+  integrity sha512-kP1sGTl64dPoHLSlmEMp2wAl+0hhuRnUsIm7sm3RI7aJ6QutN4pddVQacaMZMWfEtoR4N9Mmw+Wv6UI17AidRA==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
@@ -6245,7 +6245,7 @@ ember-source@~3.23.0-beta.5:
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^4.2.0"
     chalk "^4.0.0"
-    ember-cli-babel "^7.19.0"
+    ember-cli-babel "^7.23.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"


### PR DESCRIPTION
This PR fixes the compatibility with Ember.js 3.24 and above, specifically compatibility with https://github.com/emberjs/ember.js/pull/19080. The two primary changes are:

- `setupLink()` is now allowed to be used even if the router is already set up
- we ensure that the routing layer is fully set up (see `isRouterInitialized`) by looking at the `currentURL` property of the router service

This PR also re-enables the temporarily disabled CI jobs and adds another explicit one for the 3.24 LTS release.