### PR TITLE
fix(link-manager): Use private router API to query `currentURL` in a side-effect-free way

### DIFF
--- a/addon/services/link-manager.ts
+++ b/addon/services/link-manager.ts
@@ -1,3 +1,4 @@
+import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { addListener, removeListener } from '@ember/object/events';
 import RouteInfo from '@ember/routing/-private/route-info';
@@ -30,7 +31,15 @@ export default class LinkManagerService extends Service {
    * @see https://github.com/buschtoens/ember-link/issues/126
    */
   get isRouterInitialized() {
-    return this.router.currentURL !== null;
+    // Ideally we would use the public `router` service here, but accessing
+    // the `currentURL` on that service automatically starts the routing layer
+    // as a side-effect, which is not our intention here. Once or if Ember.js
+    // provides a flag on the `router` service to figure out if routing was
+    // already initialized we should switch back to the public service instead.
+    //
+    // Inspiration for this workaround was taken from the `currentURL()` test
+    // helper (see https://github.com/emberjs/ember-test-helpers/blob/v2.1.4/addon-test-support/@ember/test-helpers/setup-application-context.ts#L180)
+    return Boolean(getOwner(this).lookup('router:main').currentURL);
   }
 
   /**

--- a/tests/integration/components/link-test.ts
+++ b/tests/integration/components/link-test.ts
@@ -117,6 +117,33 @@ module('Integration | Component | link', function (hooks) {
           }
           assert.strictEqual(currentURL(), null);
         });
+
+        test('it does not break any following LinkTo components', async function (assert) {
+          await render(hbs`
+            <Link @route="parent.second-child" as |l|>
+              <a
+                data-test-link
+                href={{l.href}}
+                class={{if l.isActive "is-active"}}
+                {{on "click" l.transitionTo}}
+              >
+                Link
+              </a>
+            </Link>
+
+            <LinkTo @route="parent.second-child" data-test-link-to>
+              Link
+            </LinkTo>
+          `);
+
+          assert
+            .dom('[data-test-link]')
+            .hasAttribute('href', withSetupLink ? /ember\d+/ : '');
+          assert.dom('[data-test-link]').hasNoClass('is-active');
+
+          assert.dom('[data-test-link-to]').hasNoAttribute('href');
+          assert.dom('[data-test-link-to]').hasNoClass('is-active');
+        });
       });
     });
   }


### PR DESCRIPTION
As the code comment says: as soon as you use a `Link` component we internally try to figure out if the router was initialized and if we do that by accessing `currentURL` on the public `router` service, this causes the router to initialize as an unintended side-effect. This can cause issues for any following `LinkTo` components which deal with incomplete route models, as can be seen in the provided regression test.

This PR works around the problem by accessing the `currentURL` property on the private `router` instead, inspired by the `currentURL()` test helper (see https://github.com/emberjs/ember-test-helpers/blob/v2.1.4/addon-test-support/@ember/test-helpers/setup-application-context.ts#L180). This does not cause the router to initialize and thus avoids the problem mentioned above.