### PR TITLE
chore(pkg): Avoid publishing unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,7 @@
 /.github/
 /.bowerrc
 /.editorconfig
-/.ember-cli
+/.ember-cli.js
 /.env*
 /.eslintignore
 /.eslintrc.js
@@ -21,8 +21,11 @@
 /config/ember-try.js
 /CONTRIBUTING.md
 /ember-cli-build.js
+/jsconfig.json
 /testem.js
 /tests/
+/tsconfig.json
+/yarn-error.log
 /yarn.lock
 .gitkeep
 


### PR DESCRIPTION
I noticed a `yarn-error.log` file was published. Updated/Added some other files as well.