### PR TITLE
chore(pkg): [BREAKING] raise minimum Node to v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: 10
+          node-version: 12
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Browser Tests

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "typescript": "3.9.10"
   },
   "engines": {
-    "node": ">= 10.*"
+    "node": ">= 12.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This should unblock a bunch of the currently failing dependency updates.