### PR TITLE
refactor(test-helpers): [BREAKING] remove link cache

### DIFF
--- a/addon-test-support/-private/services/test-instrumented-link-manager.ts
+++ b/addon-test-support/-private/services/test-instrumented-link-manager.ts
@@ -1,32 +1,14 @@
 import { LinkParams } from 'ember-link';
 import LinkManagerService from 'ember-link/services/link-manager';
 
-import stringify from 'fast-json-stable-stringify';
-
 import TestLink from '../../test-link';
 
 export default class TestInstrumentedLinkManagerService extends LinkManagerService {
-  private _linkCache?: Map<string, TestLink>;
-
   /**
    * Creates a `UILink` instance, or a `TestLink` instance when `setupLink`
    * has been called.
    */
   createUILink(linkParams: LinkParams): TestLink {
-    if (!this._linkCache) {
-      this._linkCache = new Map();
-    }
-
-    const cacheKey = stringify(linkParams);
-
-    if (this._linkCache.has(cacheKey)) {
-      return this._linkCache.get(cacheKey) as TestLink;
-    }
-
-    const link = new TestLink(this, linkParams);
-
-    this._linkCache.set(cacheKey, link);
-
-    return link;
+    return new TestLink(this, linkParams);
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
   },
   "dependencies": {
     "@glimmer/tracking": "~1.0.3",
-    "ember-auto-import": "^1.10.1",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^6.0.0",
-    "ember-cli-typescript": "^4.1.0",
-    "fast-json-stable-stringify": "^2.1.0"
+    "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
     "@clark/ember-template-lint-config": "0.2.2",
@@ -56,6 +54,7 @@
     "@types/sinon": "10.0.6",
     "broccoli-asset-rev": "3.0.0",
     "ember-array-helper": "5.1.0",
+    "ember-auto-import": "1.10.1",
     "ember-cli": "3.28.4",
     "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-inject-live-reload": "2.1.0",

--- a/tests/unit/test-helpers/test-instrumented-link-manager-test.ts
+++ b/tests/unit/test-helpers/test-instrumented-link-manager-test.ts
@@ -17,31 +17,4 @@ module('Unit | Service | test-instrumented-link-manager', function (hooks) {
 
     assert.ok(link instanceof TestLink);
   });
-
-  test('it returns a cached test link when one exists', async function (assert) {
-    const linkManager = this.owner.lookup(
-      'service:link-manager'
-    ) as TestInstrumentedLinkManagerService;
-
-    const firstLink = linkManager.createUILink({
-      route: 'dummy',
-      models: [1, 2, { name: 'horse' }],
-      query: { page: 'yes' }
-    });
-    const secondLink = linkManager.createUILink({
-      route: 'dummy',
-      models: [1, 2, { name: 'horse' }],
-      query: { page: 'yes' }
-    });
-
-    assert.strictEqual(firstLink, secondLink);
-
-    const thirdLink = linkManager.createUILink({
-      route: 'dummy',
-      models: [1, 2, 3],
-      query: { page: 'yes' }
-    });
-
-    assert.notStrictEqual(firstLink, thirdLink);
-  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6397,7 +6397,7 @@ ember-assign-polyfill@^2.6.0:
     ember-cli-babel "^6.16.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-auto-import@^1.10.1:
+ember-auto-import@1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.10.1.tgz#6c93a875e494aa0a58b759867d3f20adfd514ae3"
   integrity sha512-7bOWzPELlVwdWDOkB+phDIjg8BNW+/2RiLLQ+Xa/eIvCLT4ABYhHV5wqW5gs5BnXTDVLfE4ddKZdllnGuPGGDQ==
@@ -8039,11 +8039,6 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
-
-fast-json-stable-stringify@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
-  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"


### PR DESCRIPTION
The link cache was intended to ensure that calling `createUILink()` with the same parameters would return the exact same instance as for earlier calls. The advantages from doing this are very small though and were causing us to need the `ember-auto-import` dependency (for `fast-json-stable-stringify`), which in turn causes us to not be compatible with Ember.js 4 at the moment. Additionally, #573 made the cache more complicated or not work at all, because passed-in functions/actions can't be serialized to JSON as a cache key.

This PR removes the link cache to resolve all of the above issues. As some apps or test suites might be relying on the current behavior, this PR is flagged as "breaking", although it should most likely not break anything for the majority of apps.