### PR TITLE
chore(deps): pin `prettier` to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "test": "ember test",
     "test:all": "ember try:each"
   },
+  "resolutions": {
+    "prettier": "2.2.1"
+  },
   "dependencies": {
     "@glimmer/tracking": "~1.0.3",
     "ember-cli-babel": "^7.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10638,7 +10638,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.1.1, prettier@^2.2.1:
+prettier@2.2.1, prettier@^2.1.1, prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==


### PR DESCRIPTION
This should hopefully unblock the lockfile update PR (#661) :)