### PR TITLE
Adjust `@glimmer/tracking` dependency to use semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prettier": "2.4.1"
   },
   "dependencies": {
-    "@glimmer/tracking": "~1.0.3",
+    "@glimmer/tracking": "^1.0.3",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^6.0.0",
     "ember-cli-typescript": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@ember/test-helpers': 2.6.0
   '@glimmer/component': 1.0.4
   '@glimmer/env': 0.1.7
-  '@glimmer/tracking': ~1.0.3
+  '@glimmer/tracking': ^1.0.3
   '@types/ember': 3.16.5
   '@types/ember-qunit': 3.4.15
   '@types/ember-test-helpers': 1.0.10


### PR DESCRIPTION
This was originally introduced with a `~` constraint, but since there is no obvious reason against using the more regular `^` constraint, this PR adjusts the dependency declaration accordingly.