### PR TITLE
Update `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,7 +13,7 @@
 /.ember-cli.js
 /.env*
 /.eslintignore
-/.eslintrc.js
+.eslintrc.js
 /.gitignore
 /.template-lintrc.js
 /.watchmanconfig
@@ -28,6 +28,7 @@
 /yarn-error.log
 /yarn.lock
 .gitkeep
+pnpm-lock.yaml
 
 # ember-try
 /.node_modules.ember-try/


### PR DESCRIPTION
#675 introduced pnpm but did not add the lockfile to the `.npmignore` file. This would cause the tarballs to be roughly 10x as large. This PR adjusts the ignore file accordingly