### PR TITLE
Fix exporting `LinkParams` and `UILinkParams` types

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,1 +1,2 @@
-export { default as Link, UILink, LinkParams, UILinkParams } from './link';
+export { default as Link, UILink } from './link';
+export type { LinkParams, UILinkParams } from './link';


### PR DESCRIPTION
Closes #717.