### PR TITLE
Allow v2 and v3 of `@ember/test-helpers`

### DIFF
--- a/ember-link/package.json
+++ b/ember-link/package.json
@@ -53,7 +53,7 @@
     "@glimmer/env": "^0.1.7"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.9.3",
+    "@ember/test-helpers": "^2.9.3 || ^3.0.0",
     "@glimmer/tracking": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This caused installation warnings from pnpm, when using `@ember/test-helpers@3` in consuming packages.

Allowing both satisfies these warnings.