### PR TITLE
fix: Fix incompatibility with ember-source/types

### DIFF
--- a/ember-link/src/services/link-manager.ts
+++ b/ember-link/src/services/link-manager.ts
@@ -68,7 +68,7 @@ export default class LinkManagerService extends Service {
   /**
    * The currently active `Transition` objects.
    */
-  get currentTransitionStack() {
+  get currentTransitionStack(): Transition[] | undefined {
     return this.internalCurrentTransitionStack;
   }
 


### PR DESCRIPTION
Fixes https://github.com/buschtoens/ember-link/issues/784

Currently `LinkManagerService#currentTransitionStack()` has an implicit return type:

```ts
export default class LinkManagerService extends Service {
  @tracked private internalCurrentTransitionStack?: Transition[];

  get currentTransitionStack() {
    return this.internalCurrentTransitionStack;
  }
}
```

Which results in the following type declaration:

```ts
declare class LinkManagerService extends Service {
  private internalCurrentTransitionStack?;

  get currentTransitionStack(): Transition<unknown>[] | undefined;
}
```

Which causes errors when using the types from `ember-source/types` because `Transition` is not generic.

Adding an explicit return type to `currentTransitionStack` seems to prevent TypeScript from expanding `Transition[]` to `Transition<unknown>[]`.

Here is the resulting type after the change:

```ts
declare class LinkManagerService extends Service {
  private internalCurrentTransitionStack?;

  get currentTransitionStack(): Transition[] | undefined;
}
```

I'm guessing there is a better way to deal with this but I'm not sure what it is.