### PR TITLE
Fix 3.38 scenario

### DIFF
--- a/test-app/package.json
+++ b/test-app/package.json
@@ -82,6 +82,11 @@
     "typescript": "^5.6.3",
     "webpack": "^5.96.1"
   },
+  "dependenciesMeta": {
+    "ember-link": {
+      "injected": true
+    }
+  },
   "engines": {
     "node": ">= 20.*"
   },


### PR DESCRIPTION
Not really sure why this works, but looks. like it fixes the 3.28 scenario.
I found this solution on this comment: https://github.com/emberjs/ember-test-helpers/issues/1489#issuecomment-2337672099