### PR TITLE
Increase Support for Node Version to 20.11

### DIFF
--- a/ember-link/package.json
+++ b/ember-link/package.json
@@ -86,7 +86,7 @@
     "typescript": "^5.6.3"
   },
   "engines": {
-    "node": ">= 20.*"
+    "node": "^20.11.0 || >=22"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "packageManager": "pnpm@9.12.2",
   "engines": {
-    "node": ">=20.*"
+    "node": "^20.11.0 || >=22"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -83,7 +83,7 @@
     "webpack": "^5.96.1"
   },
   "engines": {
-    "node": ">= 20.*"
+    "node": "^20.11.0 || >=22"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
As this is the version they added support for: `import.meta.dirname` and `import.meta.filename`

See https://nodejs.org/en/blog/release/v20.11.0